### PR TITLE
Allow Docker image tag parametrization based on git tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8-jre-alpine3.9
 
-ENV SCALA_VERSION=2.12.11
-ENV SBT_VERSION=1.3.9
+ARG SCALA_VERSION=2.12.11
+ARG SBT_VERSION=1.3.9
 ENV SCALA_HOME=/usr/share/scala
 
 RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,7 @@ RUN \
   apk del .build-dependencies && \
   rm -rf "/tmp/"*
 
+WORKDIR /root
+
 RUN \
   sbt sbtVersion

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine3.9
+FROM openjdk:8-jre-alpine@sha256:f362b165b870ef129cbe730f29065ff37399c0aa8bcab3e44b51c302938c9193
 
 ARG SCALA_VERSION=2.12.11
 ARG SBT_VERSION=1.3.9

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+IFS='_' read BASE_IMAGE SCALA_VERSION SBT_VERSION <<<"$DOCKER_TAG"
+
+if [ -n "$BASE_IMAGE" ] && [ -n "$SCALA_VERSION" ] && [ -n "$SBT_VERSION" ]
+then
+  docker build --build-arg SCALA_VERSION=$SCALA_VERSION --build-arg SBT_VERSION=$SBT_VERSION -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+else
+  docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+fi


### PR DESCRIPTION
This PR allows building a Docker image with a specific combination of Scala and sbt version based on the way the image is tagged in Git (requires a few configuration bits on DockerHub).

It fixes an issue with sbt > 1.4.0 (fails when running from /) and pins the base image, ~aiming to (probably) integrate renovatebot in the future~ leveraging dependabot to manage base image updates.